### PR TITLE
Add clickable image preview support in chat

### DIFF
--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -761,10 +761,15 @@ const ChatWindow = () => {
                 <Box key={index} sx={{ mb: 1 }}>
                   {attachment.type === 'image' ? (
                     <img
-                      src={attachment.url}
-                      alt={attachment.name}
-                      style={{ maxWidth: '180px', borderRadius: '8px' }}
-                    />
+                    src={attachment.url}
+                    alt={attachment.name}
+                    style={{
+                      maxWidth: '180px',
+                      borderRadius: '8px',
+                      cursor: 'pointer'
+                    }}
+                    onClick={() => window.open(attachment.url, '_blank')}
+                  />
                   ) : (
                     <Button
                       variant="outlined"


### PR DESCRIPTION
## Summary

* Added clickable image previews in KampusKart chat
* Shared images now open in full size in a new browser tab
* Improved image viewing experience for chat users

## Changes Made

* Added pointer cursor for image attachments
* Added click handler using `window.open()` for image previews

Fixes #75
