### PR TITLE
fix: filter lost found search by category

### DIFF
--- a/backend/services/lostfoundService.js
+++ b/backend/services/lostfoundService.js
@@ -71,11 +71,12 @@ const getSuggestions = async ({ query }) => {
   }));
 };
 
-const listItems = async ({ type, resolved, search, page, limit }) => {
+const listItems = async ({ type, category, resolved, search, page, limit }) => {
   const filter = { isDeleted: { $ne: true } };
+  const itemType = type || category;
 
-  if (type) {
-    filter.type = type;
+  if (itemType && itemType !== 'all' && itemType !== 'All') {
+    filter.type = itemType;
   }
   if (resolved !== undefined) {
     filter.resolved = resolved === 'true' || resolved === true;
@@ -84,7 +85,8 @@ const listItems = async ({ type, resolved, search, page, limit }) => {
     const searchRegex = new RegExp(escapeRegex(search), 'i');
     filter.$or = [
       { title: searchRegex },
-      { description: searchRegex }
+      { description: searchRegex },
+      { location: searchRegex }
     ];
   }
 

--- a/backend/tests/routes/lostfound.test.js
+++ b/backend/tests/routes/lostfound.test.js
@@ -104,6 +104,46 @@ describe('Lost & Found CRUD Operations', () => {
       expect(response.body.items).toHaveLength(1);
       expect(response.body.items[0].type).toBe('lost');
     });
+
+    test('should combine category alias with keyword search', async () => {
+      await LostFoundItem.create([
+        {
+          user: testUser._id,
+          type: 'lost',
+          title: 'Lost keys',
+          description: 'Black keychain',
+          location: 'Library',
+          date: '2024-01-01',
+          contact: 'test@example.com'
+        },
+        {
+          user: testUser._id,
+          type: 'found',
+          title: 'Found keys',
+          description: 'Silver keychain',
+          location: 'Library',
+          date: '2024-01-02',
+          contact: 'test@example.com'
+        },
+        {
+          user: testUser._id,
+          type: 'lost',
+          title: 'Lost notebook',
+          description: 'Blue notebook',
+          location: 'Cafeteria',
+          date: '2024-01-03',
+          contact: 'test@example.com'
+        }
+      ]);
+
+      const response = await request(app)
+        .get('/api/lostfound?category=lost&search=keys')
+        .expect(200);
+
+      expect(response.body.items).toHaveLength(1);
+      expect(response.body.items[0].title).toBe('Lost keys');
+      expect(response.body.items[0].type).toBe('lost');
+    });
   });
 
   describe('READ ONE - GET /api/lostfound/:id', () => {


### PR DESCRIPTION
## Summary
- treat category as a lost/found filter alias in the public lost-and-found listing endpoint
- keep the existing type filter behavior, with type taking precedence when both values are provided
- include location in keyword matching so public search matches suggestions/admin search behavior

## Root Cause
The list endpoint accepted type but ignored category-style filter requests. When callers searched within a category, the backend only applied the keyword search and returned matching items from every lost/found type.

## Changes Made
- Added category handling in backend/services/lostfoundService.js by mapping it to the item type filter.
- Preserved all/resolved pagination behavior.
- Added a route-level regression test for category=lost plus search=keys.

## Testing
- npm test -- --runTestsByPath tests/routes/lostfound.test.js --runInBand
- git diff --check

## Impact
Lost-and-found searches can now narrow results by category/type and keyword together, so users no longer have to scroll through unrelated found/lost items.

Fixes #160

Requested labels: gssoc:approved, level:beginner, type:bug, quality:clean.