### PR TITLE
fix: batch - hero dark mode, navbar hover, footer spacing

### DIFF
--- a/frontend/src/components/ui/footer.tsx
+++ b/frontend/src/components/ui/footer.tsx
@@ -35,7 +35,7 @@ export function Footer({
 
   return (
     <>
-      <footer className="border-t border-gray-200 bg-white pt-14 pb-8 mt-20">
+      <footer className="border-t border-gray-200 bg-white pt-10 pb-6 mt-10">
         <div className="max-w-7xl mx-auto px-6 lg:px-10">
           {/* TOP */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 pb-12">

--- a/frontend/src/components/ui/shadcnblocks-com-navbar1.tsx
+++ b/frontend/src/components/ui/shadcnblocks-com-navbar1.tsx
@@ -273,7 +273,7 @@ const renderMenuItem = (item: MenuItem) => {
     return (
       <NavigationMenuItem key={item.title}>
         <NavigationMenuTrigger
-          className="text-gray-700 dark:text-gray-200 font-semibold px-4 py-2 rounded-lg focus:outline-none focus:ring-0"
+          className="text-gray-700 dark:text-gray-200 font-semibold px-4 py-2 rounded-lg focus:outline-none focus:ring-0 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
           aria-label={`${item.title} menu`}
         >
           {item.title}

--- a/frontend/src/components/ui/shuffle-grid.tsx
+++ b/frontend/src/components/ui/shuffle-grid.tsx
@@ -119,7 +119,7 @@ export const ShuffleHero = () => {
           Your campus, simplified
         </span>
         <h1
-          className="text-2xl xs:text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold text-black leading-tight"
+          className="text-2xl xs:text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold text-black dark:text-white leading-tight"
           style={{ letterSpacing: "-0.02em" }}
         >
           Everything Campus, One App


### PR DESCRIPTION
Fixes #202, #207, #211

### Changes:
- **#202**: Hero heading text-black → text-black dark:text-white (invisible on dark bg)
- **#207**: Navbar Features/Campus triggers now have visible hover styles (bg-gray-100, text-gray-900)
- **#211**: Reduced footer vertical padding (pt-14→pt-10, pb-8→pb-6, mt-20→mt-10)
- **#218**: Already implemented as BackToTop component