### PR TITLE
Add rate limiter to complaints routes

### DIFF
--- a/backend/routes/complaints.js
+++ b/backend/routes/complaints.js
@@ -4,13 +4,20 @@ const { authMiddleware, requireAdmin } = require('../middleware/auth');
 const { sanitizeInput, validateComplaint } = require('../middleware/validation');
 const { createMemoryUpload } = require('../middleware/uploads');
 const complaintsController = require('../controllers/complaintsController');
+const { createRateLimiter } = require('../middleware/rateLimit');
 
 const upload = createMemoryUpload();
+const complaintWriteLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // same as events/news/etc.
+  message: { message: 'Too many complaints submitted, please try again later' }
+});
 
 router.get('/', authMiddleware, complaintsController.listComplaints);
 router.post(
   '/',
   authMiddleware,
+  complaintWriteLimiter,
   upload.array('images', 5),
   sanitizeInput,
   validateComplaint,
@@ -42,7 +49,7 @@ router.post(
   complaintsController.adminCleanupExpired
 );
 
-router.put('/:id', authMiddleware, upload.array('images', 5), complaintsController.updateComplaint);
-router.delete('/:id', authMiddleware, complaintsController.deleteComplaint);
+router.put('/:id', authMiddleware, complaintWriteLimiter,  upload.array('images', 5), complaintsController.updateComplaint);
+router.delete('/:id', authMiddleware, complaintWriteLimiter, complaintsController.deleteComplaint)
 
 module.exports = router;


### PR DESCRIPTION
## Problem
Complaints routes had no rate limiting, unlike other write endpoints.
This allowed spam/abuse and inconsistent backend security.

## Solution
Applied write Limiter (50 req / 15 min) to POST, PUT, DELETE in complaints.js.
Matches existing config used in events/news/facilities routes.

## Impact
- Prevents abuse of complaints module
- Ensures consistent backend protection
